### PR TITLE
Speed up scores_to_quintiles 800 times

### DIFF
--- a/precise/skatertools/m6/quintileprobabilities.py
+++ b/precise/skatertools/m6/quintileprobabilities.py
@@ -25,8 +25,8 @@ def mvn_quintile_probabilities(sgma, n_samples, mu=None):
 
 def scores_to_quintiles(x):
     ys = list()
+    q = np.quantile(x,[0.2,0.4,0.6,0.8])
     for xi in x:
-        q = np.quantile(x,[0.2,0.4,0.6,0.8])
         y = np.searchsorted(q, xi)
         ys.append(y)
     return np.array(ys)


### PR DESCRIPTION
Results from my machine:
```python

In [2]: %%time
   ...: scores_to_quintiles_2(x)
   ...: 
   ...: 
CPU times: user 43.3 ms, sys: 12.5 ms, total: 55.8 ms
Wall time: 54 ms
Out[2]: 
array([[0, 3, 4, ..., 1, 2, 4],
       [2, 0, 2, ..., 0, 1, 0],
       [4, 3, 4, ..., 0, 4, 3],
       ...,
       [4, 4, 4, ..., 0, 0, 1],
       [2, 3, 4, ..., 1, 2, 3],
       [3, 4, 4, ..., 2, 4, 2]])

In [3]: %%time
   ...: scores_to_quintiles(x)
   ...: 
   ...: 
CPU times: user 42.9 s, sys: 3.25 ms, total: 42.9 s
Wall time: 42.9 s
Out[3]: 
array([[0, 3, 4, ..., 1, 2, 4],
       [2, 0, 2, ..., 0, 1, 0],
       [4, 3, 4, ..., 0, 4, 3],
       ...,
       [4, 4, 4, ..., 0, 0, 1],
       [2, 3, 4, ..., 1, 2, 3],
       [3, 4, 4, ..., 2, 4, 2]])
```

(in the above, `scores_to_quintiles_2` is the version I'm submitting in this PR)

`q` doesn't depend on what's being iterated over, so computing it outside the loop drastically speeds things up