### PR TITLE
correct fetching of tickers

### DIFF
--- a/precise/skatertools/m6/covarianceforecasting.py
+++ b/precise/skatertools/m6/covarianceforecasting.py
@@ -6,9 +6,8 @@ from precise.skaters.covariance.runemp import run_emp_pcov_d0
 
 
 def m6_data(interval='d', n_dim=100, n_obs=300):
-    constituents = pd.read_csv(
-        'https://raw.githubusercontent.com/Mcompetitions/M6-methods/main/assets_m6.csv')[:n_dim]
-    tickers = constituents['symbol'].values
+    tickers = pd.read_csv(
+        'https://raw.githubusercontent.com/Mcompetitions/M6-methods/main/assets_m6.csv')['symbol'].unique()[:n_dim]
     if (interval=='m') and (n_obs>60):
         print('Too many obs, switching to daily ')
         interval = 'd'


### PR DESCRIPTION
the assets_m6.csv file contains a record of prices over time - to avoid issues whereby some asset might have been missing for a date, better to use `unique`