### PR TITLE
Add BlockCovariance: memory-efficient block-diagonal online covariance (O(p·b) state)

### DIFF
--- a/precise/__init__.py
+++ b/precise/__init__.py
@@ -22,6 +22,7 @@ from importlib.metadata import PackageNotFoundError, version
 from precise.adaptive import AdaptiveEwaCovariance
 from precise.assessment import all_assessors, assessor_from_name
 from precise.base import BaseOnlineCovariance
+from precise.block_covariance import BlockCovariance
 from precise.conditional import ConditionalCovariance, from_skater
 from precise.dcc import DCCCovariance
 from precise.diagonal import DiagonalCovariance
@@ -49,6 +50,7 @@ __all__ = [
     "BaseOnlineCovariance",
     "EmpiricalCovariance",
     "DiagonalCovariance",
+    "BlockCovariance",
     "EwaCovariance",
     "AdaptiveEwaCovariance",
     "LedoitWolfCovariance",

--- a/precise/block_covariance.py
+++ b/precise/block_covariance.py
@@ -1,0 +1,107 @@
+"""Memory-efficient block-diagonal online covariance.
+
+Tracks only the within-block (contiguous ``n_blocks``) recency-weighted covariances, so the
+running state and per-step cost scale with the block size ``b`` rather than the dimension
+``p``: roughly ``O(p*b)`` memory and work per observation, versus ``O(p^2)`` for a dense
+estimator. Cross-block entries are zero -- this is the memory-light, ``gamma=0``
+(block-diagonal / composite) member of the Schur family, intended for very high ``p`` where
+the dense ``p x p`` covariance is expensive or impossible to hold while streaming. A
+block-diagonal of positive-definite blocks is positive-definite, so no global
+eigen-projection (``O(p^3)``) is needed, and the precision is likewise block-wise. numpy only.
+
+Relative to ``SchurCovariance(gamma=0)`` (which keeps the full ``p x p`` EWA covariance and
+zeroes the cross-block entries only at read time), this never allocates the dense matrix in
+its state; it densifies only on a ``covariance_`` request. See microprediction/precise#47.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from precise._linalg import make_pos_def, to_symmetric
+from precise._state import ewa_burn_n, ewa_init, ewa_update
+from precise.base import BaseOnlineCovariance
+
+
+class BlockCovariance(BaseOnlineCovariance):
+    """Online block-diagonal covariance with ``O(p*b)`` state.
+
+    :param r:         Weight of the most recent observation (decay rate), in (0, 1].
+    :param n_blocks:  Number of contiguous blocks to partition the variables into.
+    :param diff:      If ``True``, estimate the covariance of first differences of the stream.
+    """
+
+    def __init__(self, r: float = 0.05, n_blocks: int = 4, diff: bool = False):
+        self.r = r
+        self.n_blocks = n_blocks
+        self.diff = diff
+        super().__init__()
+
+    def _slices(self, n_dim: int) -> list[tuple[int, int]]:
+        nb = min(max(1, self.n_blocks), n_dim)
+        return [(int(idx[0]), int(idx[-1]) + 1) for idx in np.array_split(np.arange(n_dim), nb)]
+
+    def _init_state(self, n_dim: int) -> dict:
+        sl = self._slices(n_dim)
+        return {
+            "n_dim": n_dim,
+            "n_samples": 0,
+            "r": float(self.r),
+            "n_burn": ewa_burn_n(self.r),
+            "slices": sl,
+            "subs": [ewa_init(b - a, self.r) for a, b in sl],
+        }
+
+    def _update_state(self, s: dict, x: np.ndarray) -> dict:
+        subs = []
+        for sub, (a, b) in zip(s["subs"], s["slices"]):
+            sub = {**sub, "mean": np.asarray(sub["mean"], dtype=float),
+                   "cov": np.asarray(sub["cov"], dtype=float)}
+            subs.append(ewa_update(sub, x[a:b]))
+        return {**s, "n_samples": s["n_samples"] + 1, "subs": subs}
+
+    def _state_to_cov(self, state: dict) -> np.ndarray:
+        p = state["n_dim"]
+        out = np.zeros((p, p))
+        for sub, (a, b) in zip(state["subs"], state["slices"]):
+            out[a:b, a:b] = make_pos_def(to_symmetric(np.asarray(sub["cov"], dtype=float)))
+        return out
+
+    def _state_to_mean(self, state: dict) -> np.ndarray:
+        m = np.zeros(state["n_dim"])
+        for sub, (a, b) in zip(state["subs"], state["slices"]):
+            m[a:b] = np.asarray(sub["mean"], dtype=float)
+        return m
+
+    # The state holds a list of per-block sub-dicts (nested arrays), so we serialize it
+    # explicitly to flat JSON rather than relying on the base list/array coercion.
+    def get_state(self) -> dict | None:
+        if self._state is None:
+            return None
+        s = self._state
+        return {
+            "n_dim": int(s["n_dim"]),
+            "n_samples": int(s["n_samples"]),
+            "r": float(s["r"]),
+            "n_burn": int(s["n_burn"]),
+            "slices": [[int(a), int(b)] for a, b in s["slices"]],
+            "block_means": [np.asarray(sub["mean"], dtype=float).tolist() for sub in s["subs"]],
+            "block_covs": [np.asarray(sub["cov"], dtype=float).tolist() for sub in s["subs"]],
+        }
+
+    def set_state(self, state: dict | None) -> BaseOnlineCovariance:
+        if state is None:
+            self._state = None
+            self.n_features_in_ = None
+            return self
+        n_samples, r, n_burn = int(state["n_samples"]), float(state["r"]), int(state["n_burn"])
+        slices = [(int(a), int(b)) for a, b in state["slices"]]
+        subs = [
+            {"n_dim": b - a, "n_samples": n_samples, "r": r, "n_burn": n_burn,
+             "mean": np.asarray(m, dtype=float), "cov": np.asarray(c, dtype=float)}
+            for (a, b), m, c in zip(slices, state["block_means"], state["block_covs"])
+        ]
+        self._state = {"n_dim": int(state["n_dim"]), "n_samples": n_samples, "r": r,
+                       "n_burn": n_burn, "slices": slices, "subs": subs}
+        self.n_features_in_ = int(state["n_dim"])
+        return self

--- a/precise/registry.py
+++ b/precise/registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from precise.adaptive import AdaptiveEwaCovariance
 from precise.base import BaseOnlineCovariance
+from precise.block_covariance import BlockCovariance
 from precise.dcc import DCCCovariance
 from precise.diagonal import DiagonalCovariance
 from precise.empirical import EmpiricalCovariance
@@ -27,6 +28,7 @@ from precise.tyler import TylerCovariance
 _REGISTRY: list[type[BaseOnlineCovariance]] = [
     EmpiricalCovariance,
     DiagonalCovariance,
+    BlockCovariance,
     EwaCovariance,
     AdaptiveEwaCovariance,
     LedoitWolfCovariance,

--- a/tests/test_block_covariance.py
+++ b/tests/test_block_covariance.py
@@ -1,0 +1,65 @@
+"""Tests for BlockCovariance: the memory-light block-diagonal estimator.
+
+The estimator contract (partial_fit, fitted attributes, fit==stream, state roundtrip) is
+covered by the parametrized suite in test_estimators.py. Here we check what is special:
+block-diagonal structure, positive-definiteness, sub-quadratic state, and JSON state.
+"""
+from __future__ import annotations
+
+import json
+
+import numpy as np
+
+from precise import BlockCovariance, all_estimators
+
+
+def _data(n=300, p=24, seed=0):
+    return np.random.default_rng(seed).standard_normal((n, p))
+
+
+def test_registered():
+    assert BlockCovariance in all_estimators()
+
+
+def test_block_diagonal_and_pd():
+    p, nb = 24, 4
+    e = BlockCovariance(n_blocks=nb, r=0.05).fit(_data(p=p))
+    C = e.covariance_
+    # off-block entries are exactly zero
+    block_id = np.empty(p, dtype=int)
+    for bi, idx in enumerate(np.array_split(np.arange(p), nb)):
+        block_id[idx] = bi
+    off_block = block_id[:, None] != block_id[None, :]
+    assert np.all(C[off_block] == 0.0)
+    # positive-definite by construction (block-diagonal of PD blocks)
+    assert np.all(np.linalg.eigvalsh(C) > 0)
+
+
+def test_state_is_subquadratic():
+    # the running state must scale with block size, not store a dense p x p matrix
+    p, nb = 120, 6
+    e = BlockCovariance(n_blocks=nb).fit(_data(n=400, p=p))
+    state = e.get_state()
+    block_elems = sum(np.asarray(c).size for c in state["block_covs"])
+    assert block_elems < p * p          # e.g. 6 blocks of 20 -> 2400 << 14400
+    assert "block_covs" in state and len(state["block_covs"]) == nb
+
+
+def test_state_is_json_serializable_and_roundtrips():
+    e = BlockCovariance(n_blocks=4).fit(_data())
+    state = e.get_state()
+    json.loads(json.dumps(state))                       # fully JSON-serializable
+    restored = BlockCovariance().set_state(state)
+    assert np.allclose(restored.covariance_, e.covariance_, atol=1e-12)
+
+
+def test_blocks_match_within_block_ewa():
+    # each block equals an EwaCovariance fit on that block alone
+    from precise import EwaCovariance
+    p, nb, r = 24, 4, 0.05
+    X = _data(p=p)
+    C = BlockCovariance(n_blocks=nb, r=r).fit(X).covariance_
+    a, b = np.array_split(np.arange(p), nb)[0][[0, -1]]
+    b += 1
+    Cblk = EwaCovariance(r=r).fit(X[:, a:b]).covariance_
+    assert np.allclose(C[a:b, a:b], Cblk, atol=1e-10)


### PR DESCRIPTION
## Summary
Adds `BlockCovariance` — a memory-efficient block-diagonal online covariance addressing the streaming-memory angle of #47.

`SchurCovariance(gamma=0)` produces a block-diagonal estimate but keeps the full `p×p` EWA covariance in state and zeroes cross-block entries only at read time. `BlockCovariance` instead tracks **only the within-block** (contiguous `n_blocks`) recency-weighted covariances:

- **State and per-step cost ~ `O(p·b)`** (block size `b`), not `O(p²)` — it never allocates the dense matrix while streaming; it densifies only on a `covariance_` request.
- **PD by construction** — a block-diagonal of positive-definite blocks is positive-definite, so no global `O(p³)` eigen-projection; the precision is block-wise too.
- It is the memory-light `gamma=0` (block-diagonal / composite) member of the Schur family — useful at high `p` where the dense covariance is expensive or impossible to hold (the regime #47 targets), and a natural generalization of `DiagonalCovariance` (the `b=1` case).

## Tests
- Covered by the parametrized `all_estimators()` conformance suite (contract, `fit == stream`, state roundtrip, real-JSON state).
- New `tests/test_block_covariance.py`: block-diagonal structure (off-block entries exactly zero), positive-definiteness, **sub-quadratic state** (sum of block elements `< p²`), JSON-serializable state that roundtrips, and blocks matching a within-block `EwaCovariance`.
- `ruff`, `mypy`, and full `pytest` pass locally.

## Notes
This is the block-diagonal case of #47. A general bounded-conditioning (Vecchia-style) streaming variant that keeps limited cross-block coupling without the dense matrix is a natural follow-up. Complementary to #48 (`SchurLedoitWolfCovariance`, the analytic cross-block damping).
